### PR TITLE
Add Grok computer-use streamer and update defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ![E2B Surf Preview Light](/readme-assets/surf-light.png#gh-light-mode-only)
 ![E2B Surf Preview Dark](/readme-assets/surf-dark.png#gh-dark-mode-only)
 
-# 🏄 Surf - Qwen AI Computer Use Agent + E2B Desktop
+# 🏄 Surf - Grok Computer Use Agent + E2B Desktop
 
-A Next.js application that allows Qwen AI to interact with a virtual desktop environment. This project integrates [E2B's desktop sandbox](https://github.com/e2b-dev/desktop) with Qwen3-VL-Plus from DashScope to create an AI agent that can perform tasks on a virtual computer through natural language instructions.
+A Next.js application that allows Grok from xAI to interact with a virtual desktop environment. This project integrates [E2B's desktop sandbox](https://github.com/e2b-dev/desktop) with the **grok-4-fast-non-reasoning** model to create an AI agent that can perform tasks on a virtual computer through natural language instructions.
 
 [E2B](https://e2b.dev) is an open source isolated virtual computer in the cloud made for AI use cases.
 
@@ -26,7 +26,7 @@ The application consists of several key components:
 
 1. **Frontend UI (Next.js)**: Provides the user interface with a virtual desktop view and chat interface
 2. [**E2B Desktop Sandbox**](https://github.com/e2b-dev/desktop): Creates and manages virtual desktop environments
-3. **Qwen3-VL-Plus AI**: Processes user instructions and generates actions for the AI agent using DashScope's vision-language model
+3. **Grok 4 Fast Non Reasoning**: Processes user instructions and generates actions for the AI agent using xAI's Grok API with computer and bash tools
 4. **Streaming API**: Handles real-time communication between the frontend and backend
 
 ### Core Flow
@@ -34,7 +34,7 @@ The application consists of several key components:
 1. User starts a new sandbox instance
 2. E2B creates a virtual desktop and provides a URL for streaming
 3. User sends instructions via the chat interface
-4. Backend processes the instructions using Qwen3-VL-Plus from DashScope
+4. Backend processes the instructions using xAI's Grok model with dedicated computer and bash tools
 5. AI analyzes screenshots and generates actions (clicks, typing, etc.) to perform on the virtual desktop
 6. Actions are executed on the sandbox and streamed back to the frontend
 7. The process repeats as the user continues to provide instructions
@@ -46,7 +46,7 @@ Before starting, you'll need:
 1. [Node.js](https://nodejs.org/) (version specified in package.json)
 2. [npm](https://www.npmjs.com/) (comes with Node.js)
 3. An [E2B API key](https://e2b.dev/docs/getting-started/api-key)
-4. A [DashScope API key](https://help.aliyun.com/zh/model-studio/) for Qwen3-VL-Plus access
+4. An [xAI API key](https://x.ai/) for Grok access
 
 ## Setup Instructions
 
@@ -67,7 +67,7 @@ Create a `.env.local` file in the root directory based on the provided `.env.exa
 
 ```env
 E2B_API_KEY=your_e2b_api_key
-DASHSCOPE_API_KEY=your_dashscope_api_key
+XAI_API_KEY=your_xai_api_key
 ```
 
 4. **Start the development server**
@@ -103,7 +103,7 @@ Navigate to [http://localhost:3000](http://localhost:3000) in your browser.
 ## Features
 
 - **Virtual Desktop Environment**: Runs a Linux-based desktop in a sandbox
-- **Qwen AI Integration**: Uses Qwen3-VL-Plus from DashScope for intelligent computer interactions
+- **Grok Integration**: Uses xAI's grok-4-fast-non-reasoning model with dedicated computer and bash tools for intelligent sandbox control
 - **Vision Capabilities**: AI can analyze screenshots and understand visual interfaces
 - **Real-Time Streaming**: Shows AI actions and responses as they happen
 - **Chat Interface**: Provides a conversational interface for interacting with the AI
@@ -118,7 +118,8 @@ The application uses several key dependencies:
 
 - **Next.js**: React framework for the frontend
 - **@e2b/desktop**: SDK for creating and managing desktop sandbox environments
-- **OpenAI**: SDK for interacting with DashScope's OpenAI-compatible API
+- **OpenAI**: SDK for interacting with OpenAI-compatible APIs (used for legacy integrations)
+- **@ai-sdk/xai**: Provider for accessing xAI's Grok models
 - **Tailwind CSS**: Utility-first CSS framework for styling
 - **Framer Motion**: Library for animations
 
@@ -137,9 +138,9 @@ See `package.json` for a complete list of dependencies.
 ## Troubleshooting
 
 - **Sandbox not starting**: Verify your E2B API key is correct in `.env.local`
-- **AI not responding**: Check that your DashScope API key is valid and has access to Qwen3-VL-Plus
+- **AI not responding**: Verify that your xAI API key is valid and has access to Grok
 - **Actions not working**: Ensure the sandbox is running and the AI has proper instructions
-- **Network issues**: Ensure your environment can access both E2B API and DashScope endpoints
+- **Network issues**: Ensure your environment can access both E2B API and xAI endpoints
 
 ## Contributing
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -8,6 +8,7 @@ import { SANDBOX_TIMEOUT_MS } from "@/lib/config";
 import { OpenAIComputerStreamer } from "@/lib/streaming/openai";
 import { QwenComputerStreamer } from "@/lib/streaming/qwen";
 import { MistralComputerStreamer } from "@/lib/streaming/mistral";
+import { GrokComputerStreamer } from "@/lib/streaming/grok";
 import { logError } from "@/lib/logger";
 import { ResolutionScaler } from "@/lib/streaming/resolution";
 
@@ -24,14 +25,17 @@ class StreamerFactory {
     switch (model) {
       case "mistral":
         return new MistralComputerStreamer(desktop, resolutionScaler);
+      case "grok":
+        return new GrokComputerStreamer(desktop, resolutionScaler);
       case "qwen":
         return new QwenComputerStreamer(desktop, resolutionScaler);
       case "anthropic":
       // currently not implemented
       /* return new AnthropicComputerStreamer(desktop, resolutionScaler); */
       case "openai":
-      default:
         return new OpenAIComputerStreamer(desktop, resolutionScaler);
+      default:
+        return new GrokComputerStreamer(desktop, resolutionScaler);
     }
   }
 }
@@ -48,7 +52,7 @@ export async function POST(request: Request) {
     messages,
     sandboxId,
     resolution,
-    model = "mistral",
+    model = "grok",
   } = await request.json();
 
   const apiKey = process.env.E2B_API_KEY;

--- a/components/chat/message.tsx
+++ b/components/chat/message.tsx
@@ -20,7 +20,7 @@ import {
 import { useChat } from "@/lib/chat-context";
 import { Badge } from "../ui/badge";
 import { OpenAiLogo } from "@phosphor-icons/react";
-import { AnthropicLogo, MistralLogo, QwenLogo } from "../icons";
+import { AnthropicLogo, GrokLogo, MistralLogo, QwenLogo } from "../icons";
 
 const messageVariants = cva("", {
   variants: {
@@ -137,6 +137,8 @@ export function ChatMessage({ message, className }: ChatMessageProps) {
         return <MistralLogo className="h-3 w-3" />;
       } else if (model === "qwen") {
         return <QwenLogo className="h-3 w-3" />;
+      } else if (model === "grok") {
+        return <GrokLogo className="h-3 w-3" />;
       } else {
         return <AnthropicLogo className="h-3 w-3" />;
       }

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -258,3 +258,35 @@ export const MistralLogo = ({
     </svg>
   );
 };
+
+export const GrokLogo = ({
+  size = 16,
+  className,
+}: {
+  size?: number;
+  className?: string;
+}) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="none"
+      />
+      <path
+        d="M16.5 13H12V11H19V16.5C17.857 18.709 15.285 20 12.75 20C8.469 20 5 16.642 5 12.5C5 8.358 8.469 5 12.75 5C15.029 5 17.037 5.999 18.398 7.54L16.96 8.806C15.985 7.703 14.455 7 12.75 7C9.53 7 6.906 9.507 6.906 12.5C6.906 15.493 9.53 18 12.75 18C14.269 18 15.646 17.275 16.5 16.095V13Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+};

--- a/lib/chat-context.tsx
+++ b/lib/chat-context.tsx
@@ -49,7 +49,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
   const onSandboxCreatedRef = useRef<
     ((sandboxId: string, vncUrl: string) => void) | undefined
   >(undefined);
-  const [model, setModel] = useState<ComputerModel>("mistral");
+  const [model, setModel] = useState<ComputerModel>("grok");
 
   const parseSSEEvent = (data: string): ParsedSSEEvent<typeof model> | null => {
     try {

--- a/lib/streaming/grok.ts
+++ b/lib/streaming/grok.ts
@@ -1,0 +1,407 @@
+import { Sandbox } from "@e2b/desktop";
+import { createXai } from "@ai-sdk/xai";
+import {
+  CoreMessage,
+  ToolCallPart,
+  ToolResultPart,
+  convertToCoreMessages,
+  generateText,
+  tool,
+} from "ai";
+import { z } from "zod";
+import { SSEEvent, SSEEventType } from "@/types/api";
+import {
+  ComputerInteractionStreamerFacade,
+  ComputerInteractionStreamerFacadeStreamProps,
+} from "@/lib/streaming";
+import { ActionResponse } from "@/types/api";
+import { logDebug, logError, logWarning } from "../logger";
+import { ResolutionScaler } from "./resolution";
+import {
+  GrokBashAction,
+  GrokBashCommand,
+  GrokComputerToolAction,
+  GrokToolAction,
+} from "@/types/grok";
+
+const INSTRUCTIONS = `
+You are Surf, a focused assistant powered by xAI's Grok-4-Fast-Non-Reasoning model.
+You are directly connected to an E2B desktop sandbox and MUST control it autonomously to satisfy the user's requests.
+
+Core principles:
+- Always drive the sandbox yourself. Never ask the user to run commands or perform clicks.
+- You have two tools available: "computer" for desktop interactions and "bash" for terminal commands.
+- The sandbox runs Ubuntu 22.04 with common developer tooling. Press Enter after every shell command you type.
+- Prefer using the desktop (via the computer tool) for graphical workflows and the bash tool for direct shell execution.
+- After each action, observe the updated screenshot and continue until the task is truly complete.
+
+Operate efficiently, provide concise reasoning, and ensure every instruction results in concrete control of the sandbox.
+`;
+
+const MODEL_NAME = "grok-4-fast-non-reasoning";
+
+export class GrokComputerStreamer
+  implements ComputerInteractionStreamerFacade
+{
+  public instructions: string;
+  public desktop: Sandbox;
+  public resolutionScaler: ResolutionScaler;
+  private xai = createXai({
+    apiKey: process.env.XAI_API_KEY,
+  });
+
+  constructor(desktop: Sandbox, resolutionScaler: ResolutionScaler) {
+    if (!process.env.XAI_API_KEY) {
+      throw new Error("XAI_API_KEY is not set in environment variables");
+    }
+
+    this.desktop = desktop;
+    this.resolutionScaler = resolutionScaler;
+    this.instructions = INSTRUCTIONS;
+  }
+
+  async executeAction(
+    action: GrokComputerToolAction
+  ): Promise<ActionResponse | void> {
+    const desktop = this.desktop;
+
+    logDebug("Executing Grok computer action:", action);
+
+    switch (action.action) {
+      case "take_screenshot": {
+        const screenshot = await this.resolutionScaler.takeScreenshot();
+        const screenshotBase64 = screenshot.toString("base64");
+        return {
+          action: "take_screenshot",
+          data: {
+            type: "computer_screenshot",
+            image_url: `data:image/png;base64,${screenshotBase64}`,
+          },
+        };
+      }
+      case "click":
+      case "right_click":
+      case "double_click": {
+        const [x, y] = this.resolutionScaler.scaleToOriginalSpace([
+          action.coordinate[0],
+          action.coordinate[1],
+        ]);
+
+        if (action.action === "click") {
+          await desktop.leftClick(x, y);
+        } else if (action.action === "right_click") {
+          await desktop.rightClick(x, y);
+        } else {
+          await desktop.doubleClick(x, y);
+        }
+        break;
+      }
+      case "type": {
+        await desktop.write(action.text);
+        break;
+      }
+      case "key": {
+        await desktop.press(action.key);
+        break;
+      }
+      case "scroll": {
+        const [x, y] = this.resolutionScaler.scaleToOriginalSpace([
+          action.coordinate[0],
+          action.coordinate[1],
+        ]);
+
+        await desktop.moveMouse(x, y);
+        await desktop.scroll(
+          action.direction === "up" ? "up" : "down",
+          action.amount ?? 3
+        );
+        break;
+      }
+      case "move": {
+        const [x, y] = this.resolutionScaler.scaleToOriginalSpace([
+          action.coordinate[0],
+          action.coordinate[1],
+        ]);
+        await desktop.moveMouse(x, y);
+        break;
+      }
+      case "drag": {
+        const startCoordinate = this.resolutionScaler.scaleToOriginalSpace([
+          action.start_coordinate[0],
+          action.start_coordinate[1],
+        ]);
+        const endCoordinate = this.resolutionScaler.scaleToOriginalSpace([
+          action.end_coordinate[0],
+          action.end_coordinate[1],
+        ]);
+
+        await desktop.drag(startCoordinate, endCoordinate);
+        break;
+      }
+      default: {
+        logWarning("Unknown Grok action type:", action);
+      }
+    }
+  }
+
+  async executeBashCommand(command: GrokBashCommand): Promise<string> {
+    try {
+      logDebug("Executing Grok bash command:", command);
+      const result = await this.desktop.commands.run(command.command);
+      return result.stdout || result.stderr || "Command executed successfully";
+    } catch (error) {
+      logError("Error executing Grok bash command:", error);
+      return `Error: ${error}`;
+    }
+  }
+
+  async *stream(
+    props: ComputerInteractionStreamerFacadeStreamProps
+  ): AsyncGenerator<SSEEvent<"grok">> {
+    const { messages, signal } = props;
+
+    try {
+      const formattedMessages: CoreMessage[] = convertToCoreMessages(messages);
+
+      const initialScreenshot = await this.resolutionScaler.takeScreenshot();
+      const initialScreenshotBase64 = initialScreenshot.toString("base64");
+
+      if (formattedMessages.length > 0) {
+        const lastMessage = formattedMessages[formattedMessages.length - 1];
+        if (lastMessage.role === "user" && typeof lastMessage.content === "string") {
+          lastMessage.content = [
+            { type: "text", text: lastMessage.content },
+            {
+              type: "image",
+              image: `data:image/png;base64,${initialScreenshotBase64}`,
+            },
+          ];
+        }
+      }
+
+      const tools = {
+        computer: tool({
+          description:
+            "Control the remote desktop by clicking, typing, scrolling, dragging, and capturing screenshots.",
+          parameters: z.object({
+            action: z.enum([
+              "take_screenshot",
+              "click",
+              "right_click",
+              "double_click",
+              "type",
+              "key",
+              "scroll",
+              "move",
+              "drag",
+            ]),
+            coordinate: z.tuple([z.number(), z.number()]).optional(),
+            start_coordinate: z.tuple([z.number(), z.number()]).optional(),
+            end_coordinate: z.tuple([z.number(), z.number()]).optional(),
+            text: z.string().optional(),
+            key: z.string().optional(),
+            direction: z.enum(["up", "down"]).optional(),
+            amount: z.number().optional(),
+          }),
+        }),
+        bash: tool({
+          description:
+            "Execute a Bash command directly inside the sandbox terminal and return the output.",
+          parameters: z.object({
+            command: z.string().min(1, "Command is required"),
+          }),
+        }),
+      } as const;
+
+      const createScreenshotResponse = async (
+        actionName: GrokToolAction["action"]
+      ): Promise<ActionResponse> => {
+        const screenshotBuffer = await this.resolutionScaler.takeScreenshot();
+        const screenshotBase64 = screenshotBuffer.toString("base64");
+        return {
+          action: actionName,
+          data: {
+            type: "computer_screenshot",
+            image_url: `data:image/png;base64,${screenshotBase64}`,
+          },
+        };
+      };
+
+      const extractImageData = (imageUrl: string) =>
+        imageUrl.includes(",") ? imageUrl.split(",")[1] : imageUrl;
+
+      const maxIterations = 24;
+      let iteration = 0;
+
+      while (!signal.aborted && iteration < maxIterations) {
+        iteration += 1;
+
+        const currentResult = await generateText({
+          model: this.xai.languageModel(MODEL_NAME),
+          messages: formattedMessages,
+          tools,
+          maxSteps: 1,
+          system: this.instructions,
+        });
+
+        if (currentResult.text && currentResult.text.trim().length > 0) {
+          yield {
+            type: SSEEventType.REASONING,
+            content: currentResult.text,
+          };
+
+          formattedMessages.push({
+            role: "assistant",
+            content: currentResult.text,
+          } as CoreMessage);
+        }
+
+        if (currentResult.toolCalls.length === 0) {
+          yield {
+            type: SSEEventType.DONE,
+            content: currentResult.text || "Task completed",
+          };
+          return;
+        }
+
+        for (const toolCall of currentResult.toolCalls) {
+          if (signal.aborted) {
+            break;
+          }
+
+          if (toolCall.toolName === "computer") {
+            const action = toolCall.args as GrokComputerToolAction;
+
+            yield {
+              type: SSEEventType.ACTION,
+              action,
+            };
+
+            const toolCallPart: ToolCallPart = {
+              type: "tool-call",
+              toolCallId: toolCall.toolCallId,
+              toolName: toolCall.toolName,
+              args: action,
+            };
+
+            formattedMessages.push({
+              role: "assistant",
+              content: [toolCallPart],
+            } as CoreMessage);
+
+            const actionResponse =
+              (await this.executeAction(action)) ??
+              (await createScreenshotResponse(action.action));
+
+            const imageData = extractImageData(
+              actionResponse.data.image_url
+            );
+
+            const toolResult: ToolResultPart = {
+              type: "tool-result",
+              toolCallId: toolCall.toolCallId,
+              toolName: toolCall.toolName,
+              result: actionResponse,
+              experimental_content: [
+                {
+                  type: "image",
+                  data: imageData,
+                  mimeType: "image/png",
+                },
+              ],
+            };
+
+            formattedMessages.push({
+              role: "tool",
+              content: [toolResult],
+            } as CoreMessage);
+
+            yield {
+              type: SSEEventType.ACTION_COMPLETED,
+            };
+          } else if (toolCall.toolName === "bash") {
+            const bashArgs = toolCall.args as GrokBashCommand;
+
+            const actionEvent: GrokBashAction = {
+              action: "bash",
+              command: bashArgs.command,
+            };
+
+            yield {
+              type: SSEEventType.ACTION,
+              action: actionEvent,
+            };
+
+            const toolCallPart: ToolCallPart = {
+              type: "tool-call",
+              toolCallId: toolCall.toolCallId,
+              toolName: toolCall.toolName,
+              args: bashArgs,
+            };
+
+            formattedMessages.push({
+              role: "assistant",
+              content: [toolCallPart],
+            } as CoreMessage);
+
+            const commandResult = await this.executeBashCommand(bashArgs);
+            const screenshotResponse = await createScreenshotResponse("bash");
+            const imageData = extractImageData(
+              screenshotResponse.data.image_url
+            );
+
+            const toolResult: ToolResultPart = {
+              type: "tool-result",
+              toolCallId: toolCall.toolCallId,
+              toolName: toolCall.toolName,
+              result: {
+                output: commandResult,
+                screenshot: screenshotResponse.data.image_url,
+              },
+              experimental_content: [
+                {
+                  type: "text",
+                  text: commandResult,
+                },
+                {
+                  type: "image",
+                  data: imageData,
+                  mimeType: "image/png",
+                },
+              ],
+            };
+
+            formattedMessages.push({
+              role: "tool",
+              content: [toolResult],
+            } as CoreMessage);
+
+            yield {
+              type: SSEEventType.ACTION_COMPLETED,
+            };
+          } else {
+            logWarning("Unknown Grok tool call:", toolCall);
+          }
+        }
+      }
+
+      if (signal.aborted) {
+        yield {
+          type: SSEEventType.DONE,
+          content: "Generation stopped by user",
+        };
+      } else if (iteration >= maxIterations) {
+        yield {
+          type: SSEEventType.ERROR,
+          content: "Reached maximum Grok tool iterations. Please try again.",
+        };
+      }
+    } catch (error) {
+      logError("Error in Grok stream:", error);
+      yield {
+        type: SSEEventType.ERROR,
+        content: `Grok AI error: ${error}`,
+      };
+    }
+  }
+}

--- a/types/api.ts
+++ b/types/api.ts
@@ -3,12 +3,23 @@
  */
 import { ComputerAction } from "@/types/anthropic";
 import { PixtralNonOpenAIToolAction } from "@/types/mistral";
+import { GrokToolAction } from "@/types/grok";
 import { ResponseComputerToolCall } from "openai/resources/responses/responses.mjs";
 
 /**
  * Model types supported by Surf
  */
-export type ComputerModel = "openai" | "anthropic" | "qwen" | "mistral";
+export type ComputerModel =
+  | "openai"
+  | "anthropic"
+  | "qwen"
+  | "mistral"
+  | "grok";
+
+type NonOpenAIComputerAction =
+  | ComputerAction
+  | PixtralNonOpenAIToolAction
+  | GrokToolAction;
 
 /**
  * SSE event types for client communication
@@ -37,7 +48,7 @@ export interface ActionEvent<T extends ComputerModel> extends BaseSSEEvent {
   type: SSEEventType.ACTION;
   action: T extends "openai"
     ? ResponseComputerToolCall["action"]
-    : ComputerAction | PixtralNonOpenAIToolAction;
+    : NonOpenAIComputerAction;
 }
 
 /**

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -5,6 +5,7 @@ import { ResponseComputerToolCall } from "openai/resources/responses/responses.m
 import { ActionEvent, ComputerModel, SSEEventType } from "./api";
 import { ComputerAction } from "@/types/anthropic";
 import { PixtralNonOpenAIToolAction } from "@/types/mistral";
+import { GrokToolAction } from "@/types/grok";
 
 /**
  * Role of a chat message
@@ -53,7 +54,7 @@ export interface ActionChatMessage<T extends ComputerModel = ComputerModel>
   role: "action";
   action: T extends "openai"
     ? ResponseComputerToolCall["action"]
-    : ComputerAction | PixtralNonOpenAIToolAction;
+    : ComputerAction | PixtralNonOpenAIToolAction | GrokToolAction;
   status?: "pending" | "completed" | "failed";
   model: ComputerModel;
 }

--- a/types/grok.ts
+++ b/types/grok.ts
@@ -1,0 +1,76 @@
+/**
+ * Type definitions for Grok computer-use tooling
+ */
+
+export type GrokCoordinate = [number, number];
+
+type GrokScrollDirection = "up" | "down";
+
+interface GrokToolActionBase {
+  action:
+    | "take_screenshot"
+    | "click"
+    | "right_click"
+    | "double_click"
+    | "type"
+    | "key"
+    | "scroll"
+    | "move"
+    | "drag";
+}
+
+export interface GrokScreenshotAction extends GrokToolActionBase {
+  action: "take_screenshot";
+}
+
+export interface GrokClickAction extends GrokToolActionBase {
+  action: "click" | "right_click" | "double_click";
+  coordinate: GrokCoordinate;
+}
+
+export interface GrokTypeAction extends GrokToolActionBase {
+  action: "type";
+  text: string;
+}
+
+export interface GrokKeyAction extends GrokToolActionBase {
+  action: "key";
+  key: string;
+}
+
+export interface GrokScrollAction extends GrokToolActionBase {
+  action: "scroll";
+  coordinate: GrokCoordinate;
+  direction: GrokScrollDirection;
+  amount?: number;
+}
+
+export interface GrokMoveAction extends GrokToolActionBase {
+  action: "move";
+  coordinate: GrokCoordinate;
+}
+
+export interface GrokDragAction extends GrokToolActionBase {
+  action: "drag";
+  start_coordinate: GrokCoordinate;
+  end_coordinate: GrokCoordinate;
+}
+
+export type GrokComputerToolAction =
+  | GrokScreenshotAction
+  | GrokClickAction
+  | GrokTypeAction
+  | GrokKeyAction
+  | GrokScrollAction
+  | GrokMoveAction
+  | GrokDragAction;
+
+export interface GrokBashCommand {
+  command: string;
+}
+
+export interface GrokBashAction extends GrokBashCommand {
+  action: "bash";
+}
+
+export type GrokToolAction = GrokComputerToolAction | GrokBashAction;


### PR DESCRIPTION
## Summary
- add a Grok-powered computer interaction streamer that drives the sandbox via computer and bash tools
- set Grok as the default model while updating shared types, chat state, and UI assets to recognize the new model
- refresh documentation to explain the Grok integration and new XAI API key requirement

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d83f2607c08331a1d0a0b998a9b616